### PR TITLE
drop hostname label

### DIFF
--- a/config/vector_gpu_vm.yaml
+++ b/config/vector_gpu_vm.yaml
@@ -11,6 +11,7 @@ transforms:
         inputs:
             - dcgm_metrics
         source: |
+            del(.tags.Hostname)
             .tags.vm_id = "${VM_ID}"
 
 sinks:


### PR DESCRIPTION
hostname label is the name of dcgm-exporter container which is not a required label.