### PR TITLE
replace-dcgm-exporter flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ chmod +x setup_crusoe_telemetry_agent.sh
 ```
 sudo ./setup_crusoe_telemetry_agent.sh
 ```
+
+**Note for Slurm images:** 
+If you have a pre-installed dcgm-exporter systemd service, use `--replace-dcgm-exporter` to replace it with the Crusoe version for full metrics collection. 
+Optional `SERVICE_NAME` defaults to `dcgm-exporter`:
+
+```
+sudo ./setup_crusoe_telemetry_agent.sh --replace-dcgm-exporter [SERVICE_NAME]
+```
+
 While installing the script will prompt user to enter crusoe monitoring token. Paste the token created in above step.
 Note: For enhanced security its a silent input, the token will not be displayed while pasting.
 ```

--- a/setup_crusoe_telemetry_agent.sh
+++ b/setup_crusoe_telemetry_agent.sh
@@ -27,11 +27,16 @@ CRUSOE_AUTH_TOKEN_REFRESH_ALIAS_PATH="/usr/bin/crusoe_auth_token_refresh"
 # Optional parameters with defaults
 DCGM_EXPORTER_SERVICE_NAME="crusoe-dcgm-exporter.service"
 DCGM_EXPORTER_SERVICE_PORT="9400"
+REPLACE_DCGM_EXPORTER=false
+EXISTING_DCGM_EXPORTER_SERVICE="dcgm-exporter"
 
 # CLI args parsing
 usage() {
-  echo "Usage: $0 [--dcgm-exporter-service-name NAME] [--dcgm-exporter-service-port PORT] [--branch BRANCH]"
-  echo "Defaults: NAME=crusoe-dcgm-exporter.service, PORT=9400, BRANCH=main"
+  echo "Usage: $0 [--dcgm-exporter-service-name NAME] [--dcgm-exporter-service-port PORT] [--branch BRANCH] [--replace-dcgm-exporter [SERVICE_NAME]]"
+  echo "Defaults: NAME=crusoe-dcgm-exporter, PORT=9400, BRANCH=main"
+  echo "Options:"
+  echo "  --replace-dcgm-exporter [SERVICE_NAME]    Replace pre-installed dcgm-exporter systemd service with Crusoe version for full metrics collection."
+  echo "                                            Optional SERVICE_NAME defaults to dcgm-exporter"
 }
 
 parse_args() {
@@ -39,7 +44,8 @@ parse_args() {
     case "$1" in
       --dcgm-exporter-service-name|-n)
         if [[ -n "$2" ]]; then
-          DCGM_EXPORTER_SERVICE_NAME="$2"; shift 2
+          DCGM_EXPORTER_SERVICE_NAME=$(ensure_service_suffix "$2")
+          shift 2
         else
           error_exit "Missing value for $1"
         fi
@@ -58,6 +64,16 @@ parse_args() {
           error_exit "Missing value for $1"
         fi
         ;;
+      --replace-dcgm-exporter)
+        REPLACE_DCGM_EXPORTER=true
+        shift
+        # Check if next argument is a service name (not a flag)
+        if [[ -n "$1" && "$1" != --* ]]; then
+          EXISTING_DCGM_EXPORTER_SERVICE="$1"
+          shift
+        fi
+        EXISTING_DCGM_EXPORTER_SERVICE=$(ensure_service_suffix "$EXISTING_DCGM_EXPORTER_SERVICE")
+        ;;
       --help|-h)
         usage; exit 0;;
       *)
@@ -71,10 +87,34 @@ service_exists() {
   systemctl cat "$1" >/dev/null 2>&1
 }
 
+# Stop and disable a systemd service if it exists
+stop_and_disable_service() {
+  local service_name="$1"
+  if service_exists "$service_name"; then
+    echo "Found $service_name."
+    systemctl stop "$service_name" || echo "Warning: Failed to stop $service_name"
+    systemctl disable "$service_name" || echo "Warning: Failed to disable $service_name"
+    echo "$service_name has been stopped and disabled."
+    return 0
+  else
+    echo "No $service_name found."
+    return 1
+  fi
+}
+
 # --- Helper Functions ---
 
 command_exists() {
   command -v "$1" >/dev/null 2>&1
+}
+
+ensure_service_suffix() {
+  local service_name="$1"
+  if [[ "$service_name" != *.service ]]; then
+    echo "${service_name}.service"
+  else
+    echo "$service_name"
+  fi
 }
 
 file_exists() {
@@ -209,10 +249,13 @@ if $HAS_NVIDIA_GPUS; then
   status "Download GPU Vector config."
   wget -q -O "$CRUSOE_TELEMETRY_AGENT_DIR/vector.yaml" "$GITHUB_RAW_BASE_URL/$REMOTE_VECTOR_CONFIG_GPU_VM" || error_exit "Failed to download $REMOTE_VECTOR_CONFIG_GPU_VM"
 
-  # Only download DCGM Exporter artifacts if the specified service does not already exist
-  if service_exists "$DCGM_EXPORTER_SERVICE_NAME"; then
-    echo "$DCGM_EXPORTER_SERVICE_NAME already exists. Skipping DCGM Exporter compose and service download."
-  else
+  if $REPLACE_DCGM_EXPORTER; then
+    status "Checking for pre-installed dcgm-exporter service: $EXISTING_DCGM_EXPORTER_SERVICE"
+    stop_and_disable_service "$EXISTING_DCGM_EXPORTER_SERVICE"
+  fi
+
+  # Download DCGM Exporter artifacts if service does not exist or replace flag is set
+  if ! service_exists "$DCGM_EXPORTER_SERVICE_NAME" || $REPLACE_DCGM_EXPORTER; then
     status "Download DCGM Exporter docker-compose file."
     wget -q -O "$CRUSOE_TELEMETRY_AGENT_DIR/docker-compose-dcgm-exporter.yaml" "$GITHUB_RAW_BASE_URL/$REMOTE_DOCKER_COMPOSE_DCGM_EXPORTER_UBUNTU_22" || error_exit "Failed to download $REMOTE_DOCKER_COMPOSE_DCGM_EXPORTER_UBUNTU_22"
 

--- a/vm/DEBIAN_PACKAGING.md
+++ b/vm/DEBIAN_PACKAGING.md
@@ -122,6 +122,16 @@ export CRUSOE_ENVIRONMENT="staging"
 sudo -E apt install ./crusoe-telemetry-agent_*.deb
 ```
 
+### Note for Slurm images
+
+If you have a pre-installed dcgm-exporter systemd service, use `REPLACE_DCGM_EXPORTER=true` to replace it with the Crusoe version for full metrics collection.
+Optional `EXISTING_DCGM_EXPORTER_SERVICE` defaults to `dcgm-exporter`:
+```bash
+export REPLACE_DCGM_EXPORTER=true
+export EXISTING_DCGM_EXPORTER_SERVICE="my-dcgm-exporter"
+sudo -E apt install ./crusoe-telemetry-agent_*.deb
+```
+
 ## Post-Installation
 
 ### Set Token (if not provided during install)
@@ -224,8 +234,10 @@ The package respects these environment variables during installation:
 
 - `CRUSOE_AUTH_TOKEN` - Monitoring token (82 chars)
 - `CRUSOE_ENVIRONMENT` - Environment: prod (default), staging, dev
-- `DCGM_EXPORTER_SERVICE_NAME` - Custom DCGM service name (default: crusoe-dcgm-exporter.service)
+- `DCGM_EXPORTER_SERVICE_NAME` - Custom DCGM service name (default: crusoe-dcgm-exporter)
 - `DCGM_EXPORTER_SERVICE_PORT` - Custom DCGM port (default: 9400)
+- `REPLACE_DCGM_EXPORTER` - Replace pre-installed dcgm-exporter: true or false (default: false)
+- `EXISTING_DCGM_EXPORTER_SERVICE` - Name of pre-installed dcgm-exporter service to replace (default: dcgm-exporter)
 
 ## Package Dependencies
 

--- a/vm/debian/README.Debian
+++ b/vm/debian/README.Debian
@@ -41,6 +41,17 @@ On GPU VMs, the package will automatically:
 - Install and start the DCGM Exporter service
 - Configure GPU-specific metrics collection
 
+For Slurm Images with Pre-installed DCGM Exporter
+--------------------------------------------------
+
+If you have a pre-installed dcgm-exporter systemd service, you can replace
+it with the Crusoe version for full metrics collection.
+Optional `EXISTING_DCGM_EXPORTER_SERVICE` defaults to `dcgm-exporter`:
+
+   export REPLACE_DCGM_EXPORTER=true
+   export EXISTING_DCGM_EXPORTER_SERVICE="my-dcgm-exporter"
+   sudo -E apt install ./crusoe-telemetry-agent_*.deb
+
 Services
 --------
 

--- a/vm/debian/postinst
+++ b/vm/debian/postinst
@@ -22,6 +22,8 @@ INSTALLED_VERSION_FILE="$CRUSOE_TELEMETRY_AGENT_DIR/VERSION"
 DEFAULT_DCGM_EXPORTER_SERVICE_NAME="crusoe-dcgm-exporter.service"
 DCGM_EXPORTER_SERVICE_NAME="${DCGM_EXPORTER_SERVICE_NAME:-$DEFAULT_DCGM_EXPORTER_SERVICE_NAME}"
 DCGM_EXPORTER_SERVICE_PORT="${DCGM_EXPORTER_SERVICE_PORT:-9400}"
+REPLACE_DCGM_EXPORTER="${REPLACE_DCGM_EXPORTER:-false}"
+EXISTING_DCGM_EXPORTER_SERVICE="${EXISTING_DCGM_EXPORTER_SERVICE:-dcgm-exporter}"
 
 # dcgm-exporter docker image version map
 declare -A -r DCGM_EXPORTER_VERSION_MAP=(
@@ -43,8 +45,31 @@ command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
+ensure_service_suffix() {
+  local service_name="$1"
+  if [[ "$service_name" != *.service ]]; then
+    echo "${service_name}.service"
+  else
+    echo "$service_name"
+  fi
+}
+
 service_exists() {
   systemctl cat "$1" >/dev/null 2>&1
+}
+
+stop_and_disable_service() {
+  local service_name="$1"
+  if service_exists "$service_name"; then
+    echo "Found $service_name."
+    systemctl stop "$service_name" || echo "Warning: Failed to stop $service_name"
+    systemctl disable "$service_name" || echo "Warning: Failed to disable $service_name"
+    echo "$service_name has been stopped and disabled."
+    return 0
+  else
+    echo "No $service_name found."
+    return 1
+  fi
 }
 
 error_exit() {
@@ -129,6 +154,10 @@ case "$1" in
   configure)
     status "Configuring Crusoe Telemetry Agent."
     
+    # Ensure service names have .service suffix
+    DCGM_EXPORTER_SERVICE_NAME=$(ensure_service_suffix "$DCGM_EXPORTER_SERVICE_NAME")
+    EXISTING_DCGM_EXPORTER_SERVICE=$(ensure_service_suffix "$EXISTING_DCGM_EXPORTER_SERVICE")
+    
     # Ensure docker is installed
     if ! command_exists docker; then
       error_exit "Docker is required but not installed. Please install docker.io or docker-ce package."
@@ -163,8 +192,14 @@ case "$1" in
       cp "$PACKAGE_DATA_DIR/config/vector_gpu_vm.yaml" "$CRUSOE_TELEMETRY_AGENT_DIR/vector.yaml"
       cp "$PACKAGE_DATA_DIR/docker/docker-compose-dcgm-exporter.yaml" "$CRUSOE_TELEMETRY_AGENT_DIR/"
       
-      # Install DCGM Exporter systemd service if it doesn't exist
-      if ! service_exists "$DCGM_EXPORTER_SERVICE_NAME"; then
+      # Handle replace-dcgm-exporter flag
+      if [[ "$REPLACE_DCGM_EXPORTER" == "true" ]]; then
+        status "Checking for pre-installed dcgm-exporter service: $EXISTING_DCGM_EXPORTER_SERVICE"
+        stop_and_disable_service "$EXISTING_DCGM_EXPORTER_SERVICE"
+      fi
+      
+      # Install DCGM Exporter systemd service if it doesn't exist or replace flag is set
+      if ! service_exists "$DCGM_EXPORTER_SERVICE_NAME" || [[ "$REPLACE_DCGM_EXPORTER" == "true" ]]; then
         status "Installing $DCGM_EXPORTER_SERVICE_NAME systemd unit."
         cp "$PACKAGE_DATA_DIR/systemctl/crusoe-dcgm-exporter.service" "$SYSTEMCTL_DIR/$DCGM_EXPORTER_SERVICE_NAME"
       else


### PR DESCRIPTION
VMs with a pre-existing dcgm-exporter (installed in slurm images) experience a resource conflict when the crusoe-telemetry-agent attempts to install its own crusoe-dcgm-exporter. This causes a port bind conflict (default port 9400), resulting in the new container continuously restarting and metrics failing to report.

The legacy dcgm-exporter service and container can be stopped and removed prior to agent installation to resolve this issue. 

We set this as a flag during agent installation in case customers have any existing workflows those will get disrupted with this change. 